### PR TITLE
install-terraform-ubuntu-guide.md is added

### DIFF
--- a/install-terraform-ubuntu-guide.md
+++ b/install-terraform-ubuntu-guide.md
@@ -1,0 +1,50 @@
+```
+HashiCorp officially maintains and signs packages for the following Linux distributions.
+
+- Ubuntu/Debian
+- CentOS/RHEL
+- Fedora 40
+- Fedora 41
+- Amazon Linux
+
+Ensure that your system is up to date and you have installed the gnupg, software-properties-common, and curl packages installed. You will use these packages to verify HashiCorp's GPG signature and install HashiCorp's Debian package repository.
+
+$ sudo apt-get update && sudo apt-get install -y gnupg software-properties-common
+
+Install the HashiCorp GPG key.
+
+$ wget -O- https://apt.releases.hashicorp.com/gpg | \
+gpg --dearmor | \
+sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg > /dev/null
+
+Verify the key's fingerprint.
+
+$ gpg --no-default-keyring \
+--keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg \
+--fingerprint
+
+The gpg command will report the key fingerprint:
+
+/usr/share/keyrings/hashicorp-archive-keyring.gpg
+-------------------------------------------------
+pub   rsa4096 XXXX-XX-XX [SC]
+AAAA AAAA AAAA AAAA
+uid           [ unknown] HashiCorp Security (HashiCorp Package Signing) <security+packaging@hashicorp.com>
+sub   rsa4096 XXXX-XX-XX [E]
+
+Tip
+
+Refer to the Official Packaging Guide for the latest public signing key. You can also verify the key on Security at HashiCorp under Linux Package Checksum Verification.
+
+Add the official HashiCorp repository to your system. The lsb_release -cs command finds the distribution release codename for your current system, such as buster, groovy, or sid.
+
+$ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+
+Download the package information from HashiCorp.
+
+$ sudo apt update
+
+Install Terraform from the new repository.
+
+$ sudo apt-get install terraform
+```


### PR DESCRIPTION
This is a brief installation guide for setting up Terraform—an open-source infrastructure-as-code tool—on Debian/Ubuntu-based Linux systems using HashiCorp’s official APT repository.